### PR TITLE
This exception is not useful, but causes problems when mergen more than

### DIFF
--- a/src-library/magellan/library/GameData.java
+++ b/src-library/magellan/library/GameData.java
@@ -536,7 +536,7 @@ public abstract class GameData implements Cloneable, Addeable {
    */
   public void addOldUnit(Unit newUnit) {
     if (oldUnitsView().containsKey(newUnit.getID()))
-      throw new IllegalArgumentException(newUnit + " already exists");
+      return;
 
     oldUnitsView().put(newUnit.getID(), newUnit);
   }

--- a/src-test/magellan/library/GameDataMergerTest.java
+++ b/src-test/magellan/library/GameDataMergerTest.java
@@ -1,0 +1,16 @@
+package magellan.library;
+
+import org.junit.Test;
+
+import magellan.test.GameDataBuilder;
+
+public class GameDataMergerTest {
+	  @Test
+	  public void mergeThreeReports() throws Exception {
+		  GameData gd1 = new GameDataBuilder().createSimpleGameData(1, true);
+		  GameData gd2 = new GameDataBuilder().createSimpleGameData(2, true);
+		  GameData gd3 = new GameDataBuilder().createSimpleGameData(3, false);
+		  GameData firstMerge = GameDataMerger.merge(gd3, gd2);
+		  GameDataMerger.merge(gd1, firstMerge);
+	  }
+}


### PR DESCRIPTION
2 reports

Exception while merging report
java.lang.IllegalArgumentException: Unit c8ey (c8ey) already exists
    at magellan.library.GameData.addOldUnit(GameData.java:539)
    at magellan.library.GameDataMerger.addOldUnits(GameDataMerger.java:901)
    at magellan.library.GameDataMerger.mergeIt(GameDataMerger.java:617)
    at magellan.library.GameDataMerger.merge(GameDataMerger.java:100)
    at magellan.library.utils.ReportMerger.mergeReport(ReportMerger.java:520)
    at magellan.library.utils.ReportMerger.mergeThread(ReportMerger.java:339)
    at magellan.library.utils.ReportMerger$1.run(ReportMerger.java:295)
    at java.base/java.lang.Thread.run(Thread.java:834)