### PR TITLE
[FEATURE] Make add CR options persistent

### DIFF
--- a/src-client/magellan/client/actions/file/AddCRAction.java
+++ b/src-client/magellan/client/actions/file/AddCRAction.java
@@ -112,8 +112,8 @@ public class AddCRAction extends MenuAction implements GameDataListener {
     }
 
     AddCRAccessory acc = new AddCRAccessory(settings, fc);
-    acc.setSort(false);
-    acc.setInteractive(true);
+    acc.setSort(PropertiesHelper.getBoolean(settings, PropertiesHelper.ADD_CR_ACCESSORY_SORT, false));
+    acc.setInteractive(PropertiesHelper.getBoolean(settings, PropertiesHelper.ADD_CR_ACCESSORY_INTERACTIVE, true));
 
     fc.setAccessory(acc);
     fc.setDialogTitle(Resources.get("actions.addcraction.title"));
@@ -126,6 +126,8 @@ public class AddCRAction extends MenuAction implements GameDataListener {
         i++;
       }
 
+      settings.setProperty(PropertiesHelper.ADD_CR_ACCESSORY_SORT, acc.getSort() ? "true" : "false");
+      settings.setProperty(PropertiesHelper.ADD_CR_ACCESSORY_INTERACTIVE, acc.getInteractive() ? "true" : "false");
       settings.setProperty(PropertiesHelper.CLIENT_LAST_SELECTED_ADD_CR_FILEFILTER, String
           .valueOf(i));
 

--- a/src-library/magellan/library/utils/PropertiesHelper.java
+++ b/src-library/magellan/library/utils/PropertiesHelper.java
@@ -298,6 +298,12 @@ public class PropertiesHelper {
   /** Property type list (of strings) **/
   public static final String HISTORY_ACCESSORY_DIRECTORY_HISTORY = "HistoryAccessory.directoryHistory";
 
+  /** Property type boolean: */
+  public static final String ADD_CR_ACCESSORY_SORT = "AddCRAccessory.sort";
+
+  /** Property type boolean: */
+  public static final String ADD_CR_ACCESSORY_INTERACTIVE = "AddCRAccessory.interactive";
+
   /**
    * Property type list of names
    *


### PR DESCRIPTION
When I open the "Hinzufügen" dialog and change the "Sortieren" or "Interaktiv" options, I want these changes be saved to the settings.

Unfortunately I could not compile/build Magellan successfully, so I was not able to test if this works as expected.