### PR TITLE
[TASK] Start Magellan using java binary.

### DIFF
--- a/installer/magellan.sh
+++ b/installer/magellan.sh
@@ -10,9 +10,10 @@ echo "If you need to use vm options like -Xmx1000m, edit the file magellan_launc
 echo "------------------------------------------------------"
 echo
 
-./magellan_launcher
+# The magellan_launcher is not included in the release ZIP.
+#./magellan_launcher
+#exit
 
-exit
-
+# Running Magellan with the java command works perfectly.
 cd "$(dirname "$0")"
 java -Xmx1200m -jar "magellan-client.jar" "$@"


### PR DESCRIPTION
Hallo @trickert76

In jedem Release, das ich aus dem ZIP in mein Ubuntu installiere, muss ich in magellan.sh den Launcher-Aufruf und das exit auskommentieren, weil der launcher nicht mitgeliefert wird. Der Start per java funktioniert bei mir problemlos.

Deshalb erstelle ich diesen PR, damit die Sache zumindest mal dokumentiert ist.

Thalian